### PR TITLE
Show error instead of exit code if error info available

### DIFF
--- a/pandoc.js
+++ b/pandoc.js
@@ -25,7 +25,7 @@ function pdc(src, from, to, opt, cb) {
   });
 
   pandoc.on('exit', function (code) {
-    if (code != 0)
+    if (code != 0 && !err)
       return cb(new Error('pandoc exited with code '+code+'.'));
     if (error)
       return cb(new Error(error));


### PR DESCRIPTION
This is in response to issue #1. Allows for easier debugging of e.g. conversions that require additional flags to be set.
