### PR TITLE
fix spawning multiple processes at once

### DIFF
--- a/pdc.js
+++ b/pdc.js
@@ -52,7 +52,7 @@ function pdc(src, from, to, args, opts, cb) {
   });
 
   // listen on exit
-  pandoc.on('exit', function (code) {
+  pandoc.on('close', function (code) {
     var msg = '';
     if (code !== 0)
       msg += 'pandoc exited with code ' + code + (error ? ': ' : '.');


### PR DESCRIPTION
pdc wrongly return result, even if process isn't done.

http://nodejs.org/api/child_process.html#child_process_event_exit

_This event is emitted when the stdio streams of a child process have all terminated. This is distinct from 'exit', since multiple processes might share the same stdio streams._
