### PR TITLE
fix result of callback when output format is docx

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pdc(src, from, to, [args,] [opts,] callback);
     [the Node.js docs][spawn].
   * `callback` is a function that is called after parsing. It takes two
     arguments `(err, result)`, where `err` is an error or `null` and `result` is
-    a string containing the converted text.
+    a string containing the converted text(For docx, `result` is a binary buffer).
 
 ~~~ js
 pdc.path = 'pandoc';

--- a/pdc.js
+++ b/pdc.js
@@ -1,3 +1,4 @@
+var Buffer = require('buffer').Buffer;
 var spawn = require('child_process').spawn;
 
 module.exports = pdc;
@@ -38,7 +39,9 @@ function pdc(src, from, to, args, opts, cb) {
     pandoc = pdcStream(from, to, args, opts);
   }
 
-  var result = '';
+  var result = new Buffer(0);
+  var chunks = [];
+  var size = 0;
   var error = '';
 
   // listen on error
@@ -48,7 +51,8 @@ function pdc(src, from, to, args, opts, cb) {
 
   // collect result data
   pandoc.stdout.on('data', function (data) {
-    result += data;
+    chunks.push(data);
+    size += data.length;
   });
 
   // collect error data
@@ -66,7 +70,9 @@ function pdc(src, from, to, args, opts, cb) {
 
     if (msg)
       return cb(new Error(msg));
-
+    var result = Buffer.concat(chunks, size);
+    if (to.toLowerCase() !== 'docx')
+      result = result.toString();
     cb(null, result);
   });
 

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var pdc = require('./pdc.js');
 
 // print markdown
@@ -5,6 +6,13 @@ pdc('# Heading', 'markdown', 'html', function (err, result) {
   if (err)
     throw err;
   console.log(result);
+});
+
+// write docx
+pdc('# Heading docx', 'markdown', 'docx', function (err, result) {
+  if (err)
+    throw err;
+  fs.createWriteStream('test.docx').write(result);
 });
 
 // show pandoc version


### PR DESCRIPTION
The result of docx is wrong because it is not plain text. So I make this fix to correct the result by keeping docx content buffer. If you think it is unnecessary, please close it.